### PR TITLE
docs: update installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,9 +55,6 @@ CREATE DATABASE legion_db OWNER legion;
 # Enable vector extension
 CREATE EXTENSION IF NOT EXISTS vector;
 
-# Create vector index type
-CREATE ACCESS METHOD vector_l2_ops USING ivfflat;
-
 # Grant privileges
 GRANT ALL PRIVILEGES ON DATABASE legion_db TO legion;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO legion;
@@ -100,17 +97,18 @@ pyenv activate legion
 
 2. Clone the repository and install requirements:
 
-
 pip install -r requirements.txt
-```
+
+````
 
 3. Create the configuration file:
 
 ```bash
 cp config.example.yml config.yml
-```
+````
 
 4. Configure the following in `config.yml`:
+
    - Telegram bot token and chat ID
    - Database credentials
    - API keys:
@@ -217,5 +215,5 @@ By default, Legion will run a webhook listener on port 8080. If you are running 
 To set up monitoring of proxy implementation upgrades for the [upgrade handler example](extensions/examples/proxy_implementation_upgrade_handler.py), you need to set up alerts with a provider like [Quicknode](https://www.quicknode.com/) or [Alchemy](https://www.alchemy.com/). Filter events by the 'Upgraded' topic. Here is how to do it with Quicknode:
 
 ```
-tx_logs_topic0 == '0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b' 
+tx_logs_topic0 == '0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b'
 ```


### PR DESCRIPTION
I've removed the incorrect `CREATE ACCESS METHOD` command since it's not needed.
The pgvector extension automatically creates all necessary access methods and operators when you enable it with `CREATE EXTENSION IF NOT EXISTS` vector. The vector functionality will work properly with just the extension enabled.