### PR TITLE
Fix init super to init DBSessionMixin

### DIFF
--- a/src/handlers/github_event.py
+++ b/src/handlers/github_event.py
@@ -21,7 +21,8 @@ class GitHubEventHandler(Handler, DBSessionMixin):
     """Handler for GitHub events (PR and push)"""
 
     def __init__(self):
-        super().__init__()
+        Handler.__init__(self)
+        DBSessionMixin.__init__(self)
         self.logger = Logger("GitHubEventHandler")
         self.logger.debug("GitHubEventHandler initialized")
 


### PR DESCRIPTION
This fixes an issue in github_event.py::find_related_asset whereby DBSessionMixin was not getting initialised, causing the function to throw an error "Error searching for related asset:" due to un-initialised _session